### PR TITLE
Allow to use custom cache provider

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -30,6 +30,7 @@ import (
 	"github.com/docker/distribution/registry/proxy"
 	"github.com/docker/distribution/registry/storage"
 	memorycache "github.com/docker/distribution/registry/storage/cache/memory"
+	cacheprovider "github.com/docker/distribution/registry/storage/cache/provider"
 	rediscache "github.com/docker/distribution/registry/storage/cache/redis"
 	storagedriver "github.com/docker/distribution/registry/storage/driver"
 	"github.com/docker/distribution/registry/storage/driver/factory"
@@ -276,7 +277,20 @@ func NewApp(ctx context.Context, config *configuration.Configuration) *App {
 			ctxu.GetLogger(app).Infof("using inmemory blob descriptor cache")
 		default:
 			if v != "" {
-				ctxu.GetLogger(app).Warnf("unknown cache type %q, caching disabled", config.Storage["cache"])
+				name, ok := v.(string)
+				if !ok {
+					panic(fmt.Sprintf("unexpected type of value %T (string expected): %v", v, v))
+				}
+				cacheProvider, err := cacheprovider.Get(app, name, cc)
+				if err != nil {
+					panic("unable to initialize cache provider: " + err.Error())
+				}
+				localOptions := append(options, storage.BlobDescriptorCacheProvider(cacheProvider))
+				app.registry, err = storage.NewRegistry(app, app.driver, localOptions...)
+				if err != nil {
+					panic("could not create registry: " + err.Error())
+				}
+				ctxu.GetLogger(app).Infof("using %s blob descriptor cache", name)
 			}
 		}
 	}

--- a/registry/storage/cache/provider/cacheprovider.go
+++ b/registry/storage/cache/provider/cacheprovider.go
@@ -1,0 +1,37 @@
+package cacheprovider
+
+import (
+	"fmt"
+
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/registry/storage/cache"
+)
+
+// InitFunc is the type of a CacheProvider factory function and is
+// used to register the constructor for different CacheProvider backends.
+type InitFunc func(ctx context.Context, options map[string]interface{}) (cache.BlobDescriptorCacheProvider, error)
+
+var cacheProviders map[string]InitFunc
+
+// Register is used to register an InitFunc for
+// a CacheProvider backend with the given name.
+func Register(name string, initFunc InitFunc) error {
+	if cacheProviders == nil {
+		cacheProviders = make(map[string]InitFunc)
+	}
+	if _, exists := cacheProviders[name]; exists {
+		return fmt.Errorf("name already registered: %s", name)
+	}
+
+	cacheProviders[name] = initFunc
+
+	return nil
+}
+
+// Get constructs a CacheProvider with the given options using the named backend.
+func Get(ctx context.Context, name string, options map[string]interface{}) (cache.BlobDescriptorCacheProvider, error) {
+	if initFunc, exists := cacheProviders[name]; exists {
+		return initFunc(ctx, options)
+	}
+	return nil, fmt.Errorf("no cache Provider registered with name: %s", name)
+}


### PR DESCRIPTION
Upstream allow only two types of cache to be used (`rerdis` and `inmemory`). We want to have more control over caching. We need our own implementation of the cache.

Unfortunately, the code is written in such a way that it can not be generalized and offered to upstream without deep refactoring. For example, `redis` have his own configuration top-level section and is initialized at a very early stage.

The proposed code will allow us to implement our cache without much interference into the code and refactoring.

@bparees @dmage @miminar PTAL
