### PR TITLE
UPSTREAM: docker/distribution: <carry>: fix normalize unit tests

### DIFF
--- a/reference/normalize_test.go
+++ b/reference/normalize_test.go
@@ -133,28 +133,28 @@ func TestParseRepositoryInfo(t *testing.T) {
 	tcases := []tcase{
 		{
 			RemoteName:    "fooo/bar",
-			FamiliarName:  "fooo/bar",
+			FamiliarName:  "docker.io/fooo/bar",
 			FullName:      "docker.io/fooo/bar",
 			AmbiguousName: "index.docker.io/fooo/bar",
 			Domain:        "docker.io",
 		},
 		{
 			RemoteName:    "library/ubuntu",
-			FamiliarName:  "ubuntu",
+			FamiliarName:  "docker.io/library/ubuntu",
 			FullName:      "docker.io/library/ubuntu",
 			AmbiguousName: "library/ubuntu",
 			Domain:        "docker.io",
 		},
 		{
 			RemoteName:    "nonlibrary/ubuntu",
-			FamiliarName:  "nonlibrary/ubuntu",
+			FamiliarName:  "docker.io/nonlibrary/ubuntu",
 			FullName:      "docker.io/nonlibrary/ubuntu",
 			AmbiguousName: "",
 			Domain:        "docker.io",
 		},
 		{
 			RemoteName:    "other/library",
-			FamiliarName:  "other/library",
+			FamiliarName:  "docker.io/other/library",
 			FullName:      "docker.io/other/library",
 			AmbiguousName: "",
 			Domain:        "docker.io",
@@ -203,28 +203,28 @@ func TestParseRepositoryInfo(t *testing.T) {
 		},
 		{
 			RemoteName:    "library/ubuntu-12.04-base",
-			FamiliarName:  "ubuntu-12.04-base",
+			FamiliarName:  "docker.io/library/ubuntu-12.04-base",
 			FullName:      "docker.io/library/ubuntu-12.04-base",
 			AmbiguousName: "index.docker.io/library/ubuntu-12.04-base",
 			Domain:        "docker.io",
 		},
 		{
 			RemoteName:    "library/foo",
-			FamiliarName:  "foo",
+			FamiliarName:  "docker.io/library/foo",
 			FullName:      "docker.io/library/foo",
 			AmbiguousName: "docker.io/foo",
 			Domain:        "docker.io",
 		},
 		{
 			RemoteName:    "library/foo/bar",
-			FamiliarName:  "library/foo/bar",
+			FamiliarName:  "docker.io/library/foo/bar",
 			FullName:      "docker.io/library/foo/bar",
 			AmbiguousName: "",
 			Domain:        "docker.io",
 		},
 		{
 			RemoteName:    "store/foo/bar",
-			FamiliarName:  "store/foo/bar",
+			FamiliarName:  "docker.io/store/foo/bar",
 			FullName:      "docker.io/store/foo/bar",
 			AmbiguousName: "",
 			Domain:        "docker.io",
@@ -280,7 +280,7 @@ func TestParseReferenceWithTagAndDigest(t *testing.T) {
 	if _, isCanonical := ref.(Canonical); !isCanonical {
 		t.Fatalf("Reference from %q should support digest", ref)
 	}
-	if expected, actual := shortRef, FamiliarString(ref); actual != expected {
+	if expected, actual := "docker.io/library/"+shortRef, FamiliarString(ref); actual != expected {
 		t.Fatalf("Invalid parsed reference for %q: expected %q, got %q", ref, expected, actual)
 	}
 }
@@ -574,28 +574,28 @@ func TestMatch(t *testing.T) {
 			expected:  false,
 		},
 		{
-			reference: "foo/a/bar",
-			pattern:   "foo/**/ba[rz]",
+			reference: "docker.io/library/foo/a/bar",
+			pattern:   "docker.io/library/foo/**/ba[rz]",
 			expected:  true,
 		},
 		{
-			reference: "foo/b/baz",
-			pattern:   "foo/**/ba[rz]",
+			reference: "docker.io/library/foo/b/baz",
+			pattern:   "docker.io/library/foo/**/ba[rz]",
 			expected:  true,
 		},
 		{
-			reference: "foo/c/baz:tag",
-			pattern:   "foo/**/ba[rz]",
+			reference: "docker.io/library/foo/c/baz:tag",
+			pattern:   "docker.io/library/foo/**/ba[rz]",
 			expected:  true,
 		},
 		{
-			reference: "foo/c/baz:tag",
-			pattern:   "foo/*/baz:tag",
+			reference: "docker.io/library/foo/c/baz:tag",
+			pattern:   "docker.io/library/foo/*/baz:tag",
 			expected:  true,
 		},
 		{
-			reference: "foo/c/baz:tag",
-			pattern:   "foo/c/baz:tag",
+			reference: "docker.io/library/foo/c/baz:tag",
+			pattern:   "docker.io/library/foo/c/baz:tag",
 			expected:  true,
 		},
 		{


### PR DESCRIPTION
https://github.com/openshift/origin/pull/19656 changed familiar name to no longer strip
defaultDomain (i.e., "docker.io") and "library" from image references.
This PR fixes the unit tests for that change.