### PR TITLE
[WIP] Do not add default domain in ParseNormalizedName

### DIFF
--- a/reference/normalize.go
+++ b/reference/normalize.go
@@ -68,9 +68,6 @@ func splitDockerDomain(name string) (domain, remainder string) {
 	if domain == legacyDefaultDomain {
 		domain = defaultDomain
 	}
-	if domain == defaultDomain && !strings.ContainsRune(remainder, '/') {
-		remainder = officialRepoName + "/" + remainder
-	}
 	return
 }
 

--- a/reference/normalize.go
+++ b/reference/normalize.go
@@ -45,7 +45,11 @@ func ParseNormalizedNamed(s string) (Named, error) {
 		return nil, errors.New("invalid reference format: repository name must be lowercase")
 	}
 
-	ref, err := Parse(domain + "/" + remainder)
+	name := remainder
+	if domain != "" {
+		name = domain + "/" + remainder
+	}
+	ref, err := Parse(name)
 	if err != nil {
 		return nil, err
 	}
@@ -56,16 +60,11 @@ func ParseNormalizedNamed(s string) (Named, error) {
 	return named, nil
 }
 
-// splitDockerDomain splits a repository name to domain and remotename string.
-// If no valid domain is found, the default domain is used. Repository name
-// needs to be already validated before.
+// splitDockerDomain splits a repository name to domain and remotename
+// string. If no valid domain is found, then domain is "". Repository
+// name needs to be already validated before.
 func splitDockerDomain(name string) (domain, remainder string) {
-	i := strings.IndexRune(name, '/')
-	if i == -1 || (!strings.ContainsAny(name[:i], ".:") && name[:i] != "localhost") {
-		domain, remainder = defaultDomain, name
-	} else {
-		domain, remainder = name[:i], name[i+1:]
-	}
+	domain, remainder = splitRepoName(name)
 	if domain == legacyDefaultDomain {
 		domain = defaultDomain
 	}
@@ -75,26 +74,12 @@ func splitDockerDomain(name string) (domain, remainder string) {
 	return
 }
 
-// familiarizeName returns a shortened version of the name familiar
-// to to the Docker UI. Familiar names have the default domain
-// "docker.io" and "library/" repository prefix removed.
-// For example, "docker.io/library/redis" will have the familiar
-// name "redis" and "docker.io/dmcgowan/myapp" will be "dmcgowan/myapp".
-// Returns a familiarized named only reference.
+// familiarizeName is a no-op and returns named
 func familiarizeName(named namedRepository) repository {
-	repo := repository{
+	return repository{
 		domain: named.Domain(),
 		path:   named.Path(),
 	}
-
-	if repo.domain == defaultDomain {
-		repo.domain = ""
-		// Handle official repositories which have the pattern "library/<official repo name>"
-		if split := strings.Split(repo.path, "/"); len(split) == 2 && split[0] == officialRepoName {
-			repo.path = split[1]
-		}
-	}
-	return repo
 }
 
 func (r reference) Familiar() Named {

--- a/reference/normalize.go
+++ b/reference/normalize.go
@@ -34,7 +34,10 @@ func ParseNormalizedNamed(s string) (Named, error) {
 	if ok := anchoredIdentifierRegexp.MatchString(s); ok {
 		return nil, fmt.Errorf("invalid repository name (%s), cannot specify 64-byte hexadecimal strings", s)
 	}
-	domain, remainder := splitDockerDomain(s)
+	domain, remainder := splitDomain(s)
+	if domain == legacyDefaultDomain {
+		domain = defaultDomain
+	}
 	var remoteName string
 	if tagSep := strings.IndexRune(remainder, ':'); tagSep > -1 {
 		remoteName = remainder[:tagSep]
@@ -58,17 +61,6 @@ func ParseNormalizedNamed(s string) (Named, error) {
 		return nil, fmt.Errorf("reference %s has no name", ref.String())
 	}
 	return named, nil
-}
-
-// splitDockerDomain splits a repository name to domain and remotename
-// string. If no valid domain is found, then domain is "". Repository
-// name needs to be already validated before.
-func splitDockerDomain(name string) (domain, remainder string) {
-	domain, remainder = splitRepoName(name)
-	if domain == legacyDefaultDomain {
-		domain = defaultDomain
-	}
-	return
 }
 
 // familiarizeName is a no-op and returns named

--- a/reference/normalize_test.go
+++ b/reference/normalize_test.go
@@ -200,7 +200,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 		{
 			RemoteName:    "library/foo",
 			FullName:      "docker.io/library/foo",
-			AmbiguousName: "docker.io/foo",
+			AmbiguousName: "",
 			Domain:        "docker.io",
 		},
 		{
@@ -495,7 +495,7 @@ func TestNormalizedSplitHostname(t *testing.T) {
 		{
 			input:  "docker.io/foo",
 			domain: "docker.io",
-			name:   "library/foo",
+			name:   "foo",
 		},
 		{
 			input:  "docker.io/library/foo",

--- a/reference/normalize_test.go
+++ b/reference/normalize_test.go
@@ -127,104 +127,90 @@ func TestValidateRemoteName(t *testing.T) {
 
 func TestParseRepositoryInfo(t *testing.T) {
 	type tcase struct {
-		RemoteName, FamiliarName, FullName, AmbiguousName, Domain string
+		RemoteName, FullName, AmbiguousName, Domain string
 	}
 
 	tcases := []tcase{
 		{
 			RemoteName:    "fooo/bar",
-			FamiliarName:  "fooo/bar",
-			FullName:      "docker.io/fooo/bar",
-			AmbiguousName: "index.docker.io/fooo/bar",
-			Domain:        "docker.io",
+			FullName:      "fooo/bar",
+			AmbiguousName: "",
+			Domain:        "",
 		},
 		{
 			RemoteName:    "library/ubuntu",
-			FamiliarName:  "ubuntu",
-			FullName:      "docker.io/library/ubuntu",
-			AmbiguousName: "library/ubuntu",
-			Domain:        "docker.io",
+			FullName:      "library/ubuntu",
+			AmbiguousName: "",
+			Domain:        "",
 		},
 		{
 			RemoteName:    "nonlibrary/ubuntu",
-			FamiliarName:  "nonlibrary/ubuntu",
 			FullName:      "docker.io/nonlibrary/ubuntu",
 			AmbiguousName: "",
 			Domain:        "docker.io",
 		},
 		{
 			RemoteName:    "other/library",
-			FamiliarName:  "other/library",
 			FullName:      "docker.io/other/library",
 			AmbiguousName: "",
 			Domain:        "docker.io",
 		},
 		{
 			RemoteName:    "private/moonbase",
-			FamiliarName:  "127.0.0.1:8000/private/moonbase",
 			FullName:      "127.0.0.1:8000/private/moonbase",
 			AmbiguousName: "",
 			Domain:        "127.0.0.1:8000",
 		},
 		{
 			RemoteName:    "privatebase",
-			FamiliarName:  "127.0.0.1:8000/privatebase",
 			FullName:      "127.0.0.1:8000/privatebase",
 			AmbiguousName: "",
 			Domain:        "127.0.0.1:8000",
 		},
 		{
 			RemoteName:    "private/moonbase",
-			FamiliarName:  "example.com/private/moonbase",
 			FullName:      "example.com/private/moonbase",
 			AmbiguousName: "",
 			Domain:        "example.com",
 		},
 		{
 			RemoteName:    "privatebase",
-			FamiliarName:  "example.com/privatebase",
 			FullName:      "example.com/privatebase",
 			AmbiguousName: "",
 			Domain:        "example.com",
 		},
 		{
 			RemoteName:    "private/moonbase",
-			FamiliarName:  "example.com:8000/private/moonbase",
 			FullName:      "example.com:8000/private/moonbase",
 			AmbiguousName: "",
 			Domain:        "example.com:8000",
 		},
 		{
 			RemoteName:    "privatebasee",
-			FamiliarName:  "example.com:8000/privatebasee",
 			FullName:      "example.com:8000/privatebasee",
 			AmbiguousName: "",
 			Domain:        "example.com:8000",
 		},
 		{
 			RemoteName:    "library/ubuntu-12.04-base",
-			FamiliarName:  "ubuntu-12.04-base",
 			FullName:      "docker.io/library/ubuntu-12.04-base",
 			AmbiguousName: "index.docker.io/library/ubuntu-12.04-base",
 			Domain:        "docker.io",
 		},
 		{
 			RemoteName:    "library/foo",
-			FamiliarName:  "foo",
 			FullName:      "docker.io/library/foo",
 			AmbiguousName: "docker.io/foo",
 			Domain:        "docker.io",
 		},
 		{
 			RemoteName:    "library/foo/bar",
-			FamiliarName:  "library/foo/bar",
 			FullName:      "docker.io/library/foo/bar",
 			AmbiguousName: "",
 			Domain:        "docker.io",
 		},
 		{
 			RemoteName:    "store/foo/bar",
-			FamiliarName:  "store/foo/bar",
 			FullName:      "docker.io/store/foo/bar",
 			AmbiguousName: "",
 			Domain:        "docker.io",
@@ -232,7 +218,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 	}
 
 	for _, tcase := range tcases {
-		refStrings := []string{tcase.FamiliarName, tcase.FullName}
+		refStrings := []string{tcase.FullName}
 		if tcase.AmbiguousName != "" {
 			refStrings = append(refStrings, tcase.AmbiguousName)
 		}
@@ -247,9 +233,6 @@ func TestParseRepositoryInfo(t *testing.T) {
 		}
 
 		for _, r := range refs {
-			if expected, actual := tcase.FamiliarName, FamiliarName(r); expected != actual {
-				t.Fatalf("Invalid normalized reference for %q. Expected %q, got %q", r, expected, actual)
-			}
 			if expected, actual := tcase.FullName, r.String(); expected != actual {
 				t.Fatalf("Invalid canonical reference for %q. Expected %q, got %q", r, expected, actual)
 			}
@@ -259,7 +242,6 @@ func TestParseRepositoryInfo(t *testing.T) {
 			if expected, actual := tcase.RemoteName, Path(r); expected != actual {
 				t.Fatalf("Invalid remoteName for %q. Expected %q, got %q", r, expected, actual)
 			}
-
 		}
 	}
 }
@@ -270,7 +252,7 @@ func TestParseReferenceWithTagAndDigest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if expected, actual := "docker.io/library/"+shortRef, ref.String(); actual != expected {
+	if expected, actual := shortRef, ref.String(); actual != expected {
 		t.Fatalf("Invalid parsed reference for %q: expected %q, got %q", ref, expected, actual)
 	}
 
@@ -336,11 +318,11 @@ func TestParseAnyReference(t *testing.T) {
 	}{
 		{
 			Reference:  "redis",
-			Equivalent: "docker.io/library/redis",
+			Equivalent: "redis",
 		},
 		{
 			Reference:  "redis:latest",
-			Equivalent: "docker.io/library/redis:latest",
+			Equivalent: "redis:latest",
 		},
 		{
 			Reference:  "docker.io/library/redis:latest",
@@ -348,7 +330,7 @@ func TestParseAnyReference(t *testing.T) {
 		},
 		{
 			Reference:  "redis@sha256:dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9c",
-			Equivalent: "docker.io/library/redis@sha256:dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9c",
+			Equivalent: "redis@sha256:dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9c",
 		},
 		{
 			Reference:  "docker.io/library/redis@sha256:dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9c",
@@ -356,11 +338,11 @@ func TestParseAnyReference(t *testing.T) {
 		},
 		{
 			Reference:  "dmcgowan/myapp",
-			Equivalent: "docker.io/dmcgowan/myapp",
+			Equivalent: "dmcgowan/myapp",
 		},
 		{
 			Reference:  "dmcgowan/myapp:latest",
-			Equivalent: "docker.io/dmcgowan/myapp:latest",
+			Equivalent: "dmcgowan/myapp:latest",
 		},
 		{
 			Reference:  "docker.io/mcgowan/myapp:latest",
@@ -368,7 +350,7 @@ func TestParseAnyReference(t *testing.T) {
 		},
 		{
 			Reference:  "dmcgowan/myapp@sha256:dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9c",
-			Equivalent: "docker.io/dmcgowan/myapp@sha256:dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9c",
+			Equivalent: "dmcgowan/myapp@sha256:dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9c",
 		},
 		{
 			Reference:  "docker.io/dmcgowan/myapp@sha256:dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9c",
@@ -386,7 +368,7 @@ func TestParseAnyReference(t *testing.T) {
 		},
 		{
 			Reference:  "dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9",
-			Equivalent: "docker.io/library/dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9",
+			Equivalent: "dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9",
 		},
 		{
 			Reference:  "dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9",
@@ -399,7 +381,7 @@ func TestParseAnyReference(t *testing.T) {
 		},
 		{
 			Reference:  "dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9",
-			Equivalent: "docker.io/library/dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9",
+			Equivalent: "dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9",
 			Digests: []digest.Digest{
 				digest.Digest("sha256:abcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9c"),
 			},
@@ -415,7 +397,7 @@ func TestParseAnyReference(t *testing.T) {
 		},
 		{
 			Reference:  "dbcc1",
-			Equivalent: "docker.io/library/dbcc1",
+			Equivalent: "dbcc1",
 			Digests: []digest.Digest{
 				digest.Digest("sha256:dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9c"),
 				digest.Digest("sha256:abcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9c"),
@@ -423,7 +405,7 @@ func TestParseAnyReference(t *testing.T) {
 		},
 		{
 			Reference:  "dbcc1c",
-			Equivalent: "docker.io/library/dbcc1c",
+			Equivalent: "dbcc1c",
 			Digests: []digest.Digest{
 				digest.Digest("sha256:abcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9c"),
 			},
@@ -477,12 +459,12 @@ func TestNormalizedSplitHostname(t *testing.T) {
 		},
 		{
 			input:  "test_com/foo",
-			domain: "docker.io",
+			domain: "",
 			name:   "test_com/foo",
 		},
 		{
 			input:  "docker/migrator",
-			domain: "docker.io",
+			domain: "",
 			name:   "docker/migrator",
 		},
 		{
@@ -497,8 +479,8 @@ func TestNormalizedSplitHostname(t *testing.T) {
 		},
 		{
 			input:  "foo",
-			domain: "docker.io",
-			name:   "library/foo",
+			domain: "",
+			name:   "foo",
 		},
 		{
 			input:  "xn--n3h.com/foo",

--- a/reference/reference_test.go
+++ b/reference/reference_test.go
@@ -622,11 +622,6 @@ func TestParseNamed(t *testing.T) {
 			domain: "docker.io",
 			name:   "library/foo",
 		},
-		// Ambiguous case, parser will add "library/" to foo
-		{
-			input: "docker.io/foo",
-			err:   ErrNameNotCanonical,
-		},
 	}
 	for _, testcase := range testcases {
 		failf := func(format string, v ...interface{}) {

--- a/reference/reference_test.go
+++ b/reference/reference_test.go
@@ -122,7 +122,7 @@ func TestReferenceParse(t *testing.T) {
 		},
 		{
 			input:      strings.Repeat("a/", 127) + "a:tag-puts-this-over-max",
-			domain:     "a",
+			domain:     "",
 			repository: strings.Repeat("a/", 127) + "a",
 			tag:        "tag-puts-this-over-max",
 		},
@@ -167,7 +167,7 @@ func TestReferenceParse(t *testing.T) {
 		},
 		{
 			input:      "foo/foo_bar.com:8080",
-			domain:     "foo",
+			domain:     "",
 			repository: "foo/foo_bar.com",
 			tag:        "8080",
 		},


### PR DESCRIPTION
Previously `ParseNormalizedName()` would add `docker.io` as a default domain if the image reference being parsed was unqualified. This change removes that default qualification.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1583500
