### PR TITLE
[WIP] Remove normalisation in ParseNormalizedName

### DIFF
--- a/reference/normalize.go
+++ b/reference/normalize.go
@@ -45,7 +45,14 @@ func ParseNormalizedNamed(s string) (Named, error) {
 		return nil, errors.New("invalid reference format: repository name must be lowercase")
 	}
 
-	ref, err := Parse(domain + "/" + remainder)
+	var ref Reference
+	var err error
+
+	if domain != "" {
+		ref, err = Parse(domain + "/" + remainder)
+	} else {
+		ref, err = parseUnqualified(remainder)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -60,12 +67,7 @@ func ParseNormalizedNamed(s string) (Named, error) {
 // If no valid domain is found, the default domain is used. Repository name
 // needs to be already validated before.
 func splitDockerDomain(name string) (domain, remainder string) {
-	i := strings.IndexRune(name, '/')
-	if i == -1 || (!strings.ContainsAny(name[:i], ".:") && name[:i] != "localhost") {
-		domain, remainder = defaultDomain, name
-	} else {
-		domain, remainder = name[:i], name[i+1:]
-	}
+	domain, remainder = splitDomain(name)
 	if domain == legacyDefaultDomain {
 		domain = defaultDomain
 	}

--- a/reference/normalize_test.go
+++ b/reference/normalize_test.go
@@ -541,12 +541,20 @@ func TestNormalizedSplitHostname(t *testing.T) {
 			t.Logf(strconv.Quote(testcase.input)+": "+format, v...)
 			t.Fail()
 		}
-
-		named, err := ParseNormalizedNamed(testcase.input)
+		input := testcase.input
+		if testcase.domain == defaultDomain {
+			if domain, _ := splitDomain(testcase.input); domain != defaultDomain {
+				input = defaultDomain + "/" + testcase.input
+			}
+		}
+		named, err := ParseNormalizedNamed(input)
 		if err != nil {
 			failf("error parsing name: %s", err)
 		}
 		domain, name := SplitHostname(named)
+		if testcase.domain == "" {
+			domain = defaultDomain
+		}
 		if domain != testcase.domain {
 			failf("unexpected domain: got %q, expected %q", domain, testcase.domain)
 		}

--- a/reference/normalize_test.go
+++ b/reference/normalize_test.go
@@ -2,6 +2,7 @@ package reference
 
 import (
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/docker/distribution/digestset"
@@ -431,10 +432,19 @@ func TestParseAnyReference(t *testing.T) {
 	}
 
 	for _, tcase := range tcases {
+		input := tcase.Reference
+		if !imageHasDomain(tcase.Reference) {
+			if strings.HasPrefix(tcase.Equivalent, defaultDomain+"/"+officialRepoName) {
+				input = defaultDomain + "/" + officialRepoName + "/" + input
+			} else if strings.HasPrefix(tcase.Equivalent, defaultDomain) {
+				input = defaultDomain + "/" + input
+			}
+		}
+
 		var ref Reference
 		var err error
 		if len(tcase.Digests) == 0 {
-			ref, err = ParseAnyReference(tcase.Reference)
+			ref, err = ParseAnyReference(input)
 		} else {
 			ds := digestset.NewSet()
 			for _, dgst := range tcase.Digests {
@@ -442,7 +452,7 @@ func TestParseAnyReference(t *testing.T) {
 					t.Fatalf("Error adding digest %s: %v", dgst.String(), err)
 				}
 			}
-			ref, err = ParseAnyReferenceWithSet(tcase.Reference, ds)
+			ref, err = ParseAnyReferenceWithSet(input, ds)
 		}
 		if err != nil {
 			t.Fatalf("Error parsing reference %s: %v", tcase.Reference, err)

--- a/reference/normalize_test.go
+++ b/reference/normalize_test.go
@@ -267,7 +267,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 
 func TestParseReferenceWithTagAndDigest(t *testing.T) {
 	shortRef := "busybox:latest@sha256:86e0e091d0da6bde2456dbb48306f3956bbeb2eae1b5b9a43045843f69fe4aaa"
-	ref, err := ParseNormalizedNamed(shortRef)
+	ref, err := ParseNormalizedNamed("docker.io/library/" + shortRef)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Previously ParseNormalizedName() would add docker.io as a default domain if the image reference being parsed was unqualified. This change removes that addition when parsing unqualified names.

The unit test have been updated to normalise the test inputs during the execution of the tests as opposed to changing the expected/actual values in the inputs (i.e., `[]testcases`) themselves.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1583500
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1561989