### PR TITLE
[3.11] UPSTREAM: docker/distribution: 2377: registry/handlers: ignore notfound on storage driver healthcheck

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -356,7 +356,10 @@ func (app *App) RegisterHealthChecks(healthRegistries ...*health.Registry) {
 
 		storageDriverCheck := func() error {
 			_, err := app.driver.Stat(app, "/") // "/" should always exist
-			return err                          // any error will be treated as failure
+			if _, ok := err.(storagedriver.PathNotFoundError); ok {
+				err = nil // pass this through, backend is responding, but this path doesn't exist.
+			}
+			return err
 		}
 
 		if app.Config.Health.StorageDriver.Threshold != 0 {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1655641