### PR TITLE
UPSTREAM: docker/distribution: 3068: Add dualstack option to S3 stora…

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,6 +128,7 @@ storage:
     multipartcopymaxconcurrency: 100
     multipartcopythresholdsize: 33554432
     rootdirectory: /s3/object/name/prefix
+    usedualstack: false
   swift:
     username: username
     password: password

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -103,6 +103,7 @@ type DriverParameters struct {
 	UserAgent                   string
 	ObjectACL                   string
 	SessionToken                string
+	UseDualStack                bool
 }
 
 func init() {
@@ -339,6 +340,23 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		objectACL = objectACLString
 	}
 
+	useDualStackBool := false
+	useDualStack := parameters["usedualstack"]
+	switch useDualStack := useDualStack.(type) {
+	case string:
+		b, err := strconv.ParseBool(useDualStack)
+		if err != nil {
+			return nil, fmt.Errorf("the useDualStack parameter should be a boolean")
+		}
+		useDualStackBool = b
+	case bool:
+		useDualStackBool = useDualStack
+	case nil:
+		// do nothing
+	default:
+		return nil, fmt.Errorf("the useDualStack parameter should be a boolean")
+	}
+
 	sessionToken := ""
 
 	params := DriverParameters{
@@ -361,6 +379,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		fmt.Sprint(userAgent),
 		objectACL,
 		fmt.Sprint(sessionToken),
+		useDualStackBool,
 	}
 
 	return New(params)
@@ -430,6 +449,7 @@ func New(params DriverParameters) (*Driver, error) {
 	awsConfig.WithCredentials(creds)
 	awsConfig.WithRegion(params.Region)
 	awsConfig.WithDisableSSL(!params.Secure)
+	awsConfig.WithUseDualStack(params.UseDualStack)
 
 	if params.UserAgent != "" || params.SkipVerify {
 		httpTransport := http.DefaultTransport

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -38,6 +38,7 @@ func init() {
 	root, err := ioutil.TempDir("", "driver-")
 	regionEndpoint := os.Getenv("REGION_ENDPOINT")
 	sessionToken := os.Getenv("AWS_SESSION_TOKEN")
+	useDualStack := os.Getenv("S3_USE_DUALSTACK")
 	if err != nil {
 		panic(err)
 	}
@@ -76,6 +77,14 @@ func init() {
 			}
 		}
 
+		useDualStackBool := false
+		if useDualStack != "" {
+			useDualStackBool, err = strconv.ParseBool(useDualStack)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		parameters := DriverParameters{
 			accessKey,
 			secretKey,
@@ -96,6 +105,7 @@ func init() {
 			driverName + "-test",
 			objectACL,
 			sessionToken,
+			useDualStackBool,
 		}
 
 		return New(parameters)


### PR DESCRIPTION
…ge driver

Allow the storage driver to optionally use AWS SDK's dualstack mode.
This allows the registry to communicate with S3 in IPv6 environments.
Fixes #3067

Signed-off-by: Adam Kaplan <adam.kaplan@redhat.com>