### PR TITLE
UPSTREAM: docker/distribution: 3296: allow pointing to an AWS config file as a parameter for the s3 driver

### DIFF
--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -40,6 +40,7 @@ func init() {
 	sessionToken := os.Getenv("AWS_SESSION_TOKEN")
 	useDualStack := os.Getenv("S3_USE_DUALSTACK")
 	virtualHostedStyle := os.Getenv("S3_VIRTUAL_HOSTED_STYLE")
+	credentialsConfigPath := os.Getenv("AWS_SHARED_CREDENTIALS_FILE")
 	if err != nil {
 		panic(err)
 	}
@@ -116,6 +117,7 @@ func init() {
 			sessionToken,
 			useDualStackBool,
 			virtualHostedStyleBool,
+			credentialsConfigPath,
 		}
 
 		return New(parameters)


### PR DESCRIPTION
Recognize a new parameter when setting up the AWS client so that a generic AWS config file can be used instead of having to specify AWS access and secret keys.

This should allow someone to use different authentication methods beyond just access key, secret key (and optionally session token).

Using the current supported auth methods a valid file would look like:
```
[default]
aws_access_key_id = AKMYAWSACCCESSKEYID
aws_secret_access_key = myawssecretaccesskey
```

But you can also specify alternative auth methods:
```
[default]
role_arn = arn:aws:iam:ACCOUNT_NUM:role/ROLE_NAME
web_identity_token_file = /path/to/token
```

This is related to https://issues.redhat.com/browse/CO-1255