### PR TITLE
OCPBUGS-38085: UPSTREAM distribution/distribution: 4424: fix(registry/storage/driver/s3-aws): use a consistent multipart chunk size

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -61,8 +61,6 @@ target "artifact-all" {
   inherits = ["artifact"]
   platforms = [
     "linux/amd64",
-    "linux/arm/v6",
-    "linux/arm/v7",
     "linux/arm64",
     "linux/ppc64le",
     "linux/s390x"
@@ -87,8 +85,6 @@ target "image-all" {
   inherits = ["image"]
   platforms = [
     "linux/amd64",
-    "linux/arm/v6",
-    "linux/arm/v7",
     "linux/arm64",
     "linux/ppc64le",
     "linux/s390x"

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -128,32 +128,36 @@ func init() {
 			}
 		}
 
+		if objectACL == "" {
+			objectACL = s3.ObjectCannedACLPrivate
+		}
+
 		parameters := DriverParameters{
-			accessKey,
-			secretKey,
-			bucket,
-			region,
-			regionEndpoint,
-			forcePathStyleBool,
-			encryptBool,
-			keyID,
-			secureBool,
-			skipVerifyBool,
-			v4Bool,
-			minChunkSize,
-			defaultMultipartCopyChunkSize,
-			defaultMultipartCopyMaxConcurrency,
-			defaultMultipartCopyThresholdSize,
-			multipartCombineSmallPart,
-			rootDirectory,
-			storageClass,
-			driverName + "-test",
-			objectACL,
-			sessionToken,
-			useDualStackBool,
-			accelerateBool,
-			virtualHostedStyleBool,
-			credentialsConfigPath,
+			AccessKey:                   accessKey,
+			SecretKey:                   secretKey,
+			Bucket:                      bucket,
+			Region:                      region,
+			RegionEndpoint:              regionEndpoint,
+			ForcePathStyle:              forcePathStyleBool,
+			Encrypt:                     encryptBool,
+			KeyID:                       keyID,
+			Secure:                      secureBool,
+			SkipVerify:                  skipVerifyBool,
+			V4Auth:                      v4Bool,
+			ChunkSize:                   minChunkSize,
+			MultipartCopyChunkSize:      defaultMultipartCopyChunkSize,
+			MultipartCopyMaxConcurrency: defaultMultipartCopyMaxConcurrency,
+			MultipartCopyThresholdSize:  defaultMultipartCopyThresholdSize,
+			MultipartCombineSmallPart:   multipartCombineSmallPart,
+			RootDirectory:               rootDirectory,
+			StorageClass:                storageClass,
+			UserAgent:                   driverName + "-test",
+			ObjectACL:                   objectACL,
+			SessionToken:                sessionToken,
+			UseDualStack:                useDualStackBool,
+			Accelerate:                  accelerateBool,
+			VirtualHostedStyle:          virtualHostedStyleBool,
+			CredentialsConfigPath:       credentialsConfigPath,
 		}
 
 		return New(parameters)


### PR DESCRIPTION
Multipart upload issues with Cloudflare R2 using S3 api. Some S3 compatible object storage systems like R2 require that all multipart chunks are the same size. This was mostly true before, except the final chunk was larger than the requested chunk size which causes uploads to fail.
/cc @flavianmissi 
/hold