### PR TITLE
OCPBUGS-39108: avoid appending directory as file path in s3 driver Walk

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -1153,6 +1153,16 @@ func (d *driver) doWalk(parentCtx context.Context, objectCount *int64, path, pre
 				}
 			}
 
+			// in some cases the _uploads dir might be empty. when this happens, it would
+			// be appended twice to the walkInfos slice, once as [...]/_uploads and
+			// once more erroneously as [...]/_uploads/. the easiest way to avoid this is
+			// to skip appending filePath to walkInfos if it ends in "/". the loop through
+			// dirs will already have handled it in that case, so it's safe to continue this
+			// loop.
+			if strings.HasSuffix(filePath, "/") {
+				continue
+			}
+
 			walkInfos = append(walkInfos, storagedriver.FileInfoInternal{
 				FileInfoFields: storagedriver.FileInfoFields{
 					IsDir:   false,
@@ -1427,8 +1437,6 @@ func (w *writer) Size() int64 {
 	return w.size
 }
 
-// Close flushes any remaining data in the buffer and releases the buffer back
-// to the pool.
 func (w *writer) Close() error {
 	if w.closed {
 		return fmt.Errorf("already closed")


### PR DESCRIPTION
when a directory is empty, the s3 api lists it with a trailing slash. this causes the path to be appended twice to the walkInfo slice, causing purge uploads path transformations to panic when the `_uploads` is emtpy.

this adds a check for file paths ending on slash, and do not append those as regular files to the walkInfo slice.