### PR TITLE
UPSTREAM: docker/distribution: <carry>: add ap-southeast-5 region

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -42,6 +42,13 @@ import (
 	"github.com/distribution/distribution/v3/registry/storage/driver/factory"
 )
 
+// additionalRegions is a slice with regions not listed among the default
+// regions supported by aws-sdk-go v1. the v1 of the sdk is in maintenance
+// therefore it does not receive new regions as aws infrastructure grows.
+var additionalRegions = []string{
+	"ap-southeast-5",
+}
+
 const driverName = "s3aws"
 
 // minChunkSize defines the minimum multipart upload chunk size
@@ -128,6 +135,10 @@ func init() {
 		for region := range p.Regions() {
 			validRegions[region] = struct{}{}
 		}
+	}
+
+	for _, region := range additionalRegions {
+		validRegions[region] = struct{}{}
 	}
 
 	for _, objectACL := range []string{


### PR DESCRIPTION
as of now there is no plan on upstream supporting aws-sdk-go-v2. the version of aws-sdk-go we use (v1) is in maintenance mode so it does not receive new regions.

this commits adds `ap-southeast-5` as a supported region. this is added to the default list of supported regions.